### PR TITLE
Translate and format toggles and raw_text for LLamaCPPCLIPTextEncode

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -248,8 +248,8 @@ class MZ_LLamaCPPCLIPTextEncode:
             },
         }
 
-    RETURN_TYPES = ("STRING", "CONDITIONING",)
-    RETURN_NAMES = ("text", "conditioning",)
+    RETURN_TYPES = ("STRING", "CONDITIONING", "STRING")
+    RETURN_NAMES = ("text", "conditioning","text_raw")
     OUTPUT_NODE = True
     FUNCTION = "encode"
     CATEGORY = CATEGORY_NAME

--- a/__init__.py
+++ b/__init__.py
@@ -228,22 +228,24 @@ class MZ_LLamaCPPCLIPTextEncode:
     @classmethod
     def INPUT_TYPES(s):
         importlib.reload(mz_llama_cpp)
+        from . import mz_llama_core_nodes
+        style_presets = mz_llama_core_nodes.get_style_presets()
 
-        result = {
+        return {
             "required": {
+                "style_presets": (style_presets, {"default": style_presets[1]}),
+                "text": ("STRING", {"multiline": True}),
+                "translate": ([False, True], {"default": False}),
+                "keep_device": ([False, True], {"default": False}),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff}),
             },
             "optional": {
+                "clip": ("CLIP",),
                 "llama_cpp_model": ("LLamaCPPModelConfig",),
+                "llama_cpp_options": ("LLamaCPPOptions",),
+                "customize_instruct": ("CustomizeInstruct",),
             },
         }
-
-        common_input = getCommonCLIPTextEncodeInput()
-        for key in common_input["required"]:
-            result["required"][key] = common_input["required"][key]
-        for key in common_input["optional"]:
-            result["optional"][key] = common_input["optional"][key]
-
-        return result
 
     RETURN_TYPES = ("STRING", "CONDITIONING",)
     RETURN_NAMES = ("text", "conditioning",)

--- a/__init__.py
+++ b/__init__.py
@@ -235,9 +235,10 @@ class MZ_LLamaCPPCLIPTextEncode:
             "required": {
                 "style_presets": (style_presets, {"default": style_presets[1]}),
                 "text": ("STRING", {"multiline": True}),
-                "translate": ([False, True], {"default": False}),
                 "keep_device": ([False, True], {"default": False}),
                 "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff}),
+                "translate": ([False, True], {"default": False}),
+                "format": ([False, True], {"default": True}),
             },
             "optional": {
                 "clip": ("CLIP",),

--- a/mz_llama_core_nodes.py
+++ b/mz_llama_core_nodes.py
@@ -88,6 +88,7 @@ def llama_cpp_node_encode(args_dict):
     keep_device = args_dict.get("keep_device", False)
     seed = args_dict.get("seed", -1)
     translate_option = args_dict.get("translate", False)
+    format_option = args_dict.get("format", True)
     options["seed"] = seed
     options["chat_format"] = chat_format
 
@@ -201,19 +202,20 @@ def llama_cpp_node_encode(args_dict):
         if keep_device is False:
             mz_llama_cpp.freed_gpu_memory(model_file=model_file)
 
-        # 去除换行
-        while response.find("\n") != -1:
-            response = response.replace("\n", " ")
+        if format_option is True:
+            # 去除换行
+            while response.find("\n") != -1:
+                response = response.replace("\n", " ")
 
-        # 句号换成逗号
-        while response.find(".") != -1:
-            response = response.replace(".", ",")
+            # 句号换成逗号
+            while response.find(".") != -1:
+                response = response.replace(".", ",")
 
-        # 去除多余逗号
-        while response.find(",,") != -1:
-            response = response.replace(",,", ",")
-        while response.find(", ,") != -1:
-            response = response.replace(", ,", ",")
+            # 去除多余逗号
+            while response.find(",,") != -1:
+                response = response.replace(",,", ",")
+            while response.find(", ,") != -1:
+                response = response.replace(", ,", ",")
 
         if translate_option is True:
             response = mz_prompt_utils.Utils.prompt_zh_to_en(response)

--- a/mz_llama_core_nodes.py
+++ b/mz_llama_core_nodes.py
@@ -235,7 +235,7 @@ def llama_cpp_node_encode(args_dict):
         conditionings = mz_prompt_utils.Utils.a1111_clip_text_encode(
             clip, response, )
 
-    return {"ui": {"string": [mz_prompt_utils.Utils.to_debug_prompt(response, translate_option),]}, "result": (response, conditionings)}
+    return {"ui": {"string": [mz_prompt_utils.Utils.to_debug_prompt(response, translate_option),]}, "result": (response, conditionings, response)}
 
 
 def image_interrogator_captioner(args_dict):

--- a/mz_llama_core_nodes.py
+++ b/mz_llama_core_nodes.py
@@ -87,6 +87,7 @@ def llama_cpp_node_encode(args_dict):
     options = args_dict.get("llama_cpp_options", {})
     keep_device = args_dict.get("keep_device", False)
     seed = args_dict.get("seed", -1)
+    translate_option = args_dict.get("translate", False)
     options["seed"] = seed
     options["chat_format"] = chat_format
 
@@ -214,7 +215,8 @@ def llama_cpp_node_encode(args_dict):
         while response.find(", ,") != -1:
             response = response.replace(", ,", ",")
 
-        response = mz_prompt_utils.Utils.prompt_zh_to_en(response)
+        if translate_option is True:
+            response = mz_prompt_utils.Utils.prompt_zh_to_en(response)
 
         style_presets_prompt_text = style_presets_prompt.get(style_presets, "")
 
@@ -231,7 +233,7 @@ def llama_cpp_node_encode(args_dict):
         conditionings = mz_prompt_utils.Utils.a1111_clip_text_encode(
             clip, response, )
 
-    return {"ui": {"string": [mz_prompt_utils.Utils.to_debug_prompt(response),]}, "result": (response, conditionings)}
+    return {"ui": {"string": [mz_prompt_utils.Utils.to_debug_prompt(response, translate_option),]}, "result": (response, conditionings)}
 
 
 def image_interrogator_captioner(args_dict):

--- a/mz_prompt_utils.py
+++ b/mz_prompt_utils.py
@@ -736,21 +736,24 @@ class Utils:
 
         return Utils.en2zh(text)
 
-    def to_debug_prompt(p):
-        if p is None:
-            return ""
-        zh = Utils.en2zh(p)
-        if p == zh:
-            return p
-        zh = Utils.split_en_to_zh(p)
-        p = p.strip()
-        return f"""
+    def to_debug_prompt(p, z):
+        if z is True:
+            if p is None:
+                return ""
+            zh = Utils.en2zh(p)
+            if p == zh:
+                return p
+            zh = Utils.split_en_to_zh(p)
+            p = p.strip()
+            return f"""
 原文:
 {p}
 
 中文翻译:
 {zh}
 """
+        else:
+            return p
 
     def get_gguf_files():
         gguf_dir = Utils.get_gguf_models_path()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+diskcache
+llama-cpp-python


### PR DESCRIPTION
<img width="2388" height="1470" alt="2025-08-13-165635_hyprshot" src="https://github.com/user-attachments/assets/7d236d18-df44-4ef7-b9ec-0443ca167849" />

By allowing the user to control formatting, and providing a raw_text output, this enables one to parse <think> and content tags with custom instructions (See image). And translation is unnecessary for some of us and makes the output difficult to parse.

The raw_text output was necessary because text node inputs take a result object and not a STRING